### PR TITLE
Update Neo4j Docker image to 5.10.0-enterprise to align with ARCH Search

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   neo4j:
-    image: neo4j:4.3.17-enterprise
+    image: neo4j:5.10.0-enterprise
     ports:
       # - 'host':'container'
       - '7474:7474' # Remote interface: exposes neo4j browser // GUI port


### PR DESCRIPTION
Does as advertised. This is just getting us caught up with ARCH Search.